### PR TITLE
EF Value Generator for int and long backed Id's 

### DIFF
--- a/src/StronglyTypedIds/Templates/Int/Int_EfCoreValueConverter.cs
+++ b/src/StronglyTypedIds/Templates/Int/Int_EfCoreValueConverter.cs
@@ -9,3 +9,15 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<TESTID>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override TESTID Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new TESTID(_id);
+            }
+        }

--- a/src/StronglyTypedIds/Templates/Long/Long_EfCoreValueConverter.cs
+++ b/src/StronglyTypedIds/Templates/Long/Long_EfCoreValueConverter.cs
@@ -9,3 +9,15 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<TESTID>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override TESTID Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new TESTID(_id);
+            }
+        }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Int_implementations=0.verified.txt
@@ -45,5 +45,17 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }
 }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Int_implementations=2.verified.txt
@@ -45,5 +45,17 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }
 }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Int_implementations=4.verified.txt
@@ -46,5 +46,17 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }
 }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Int_implementations=6.verified.txt
@@ -46,5 +46,17 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }
 }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Long_implementations=0.verified.txt
@@ -45,5 +45,17 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }
 }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Long_implementations=2.verified.txt
@@ -45,5 +45,17 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }
 }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Long_implementations=4.verified.txt
@@ -46,5 +46,17 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }
 }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=16_backingType=Long_implementations=6.verified.txt
@@ -46,5 +46,17 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }
 }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Int_implementations=0.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Int_implementations=2.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Int_implementations=4.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Int_implementations=6.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Long_implementations=0.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Long_implementations=2.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Long_implementations=4.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=18_backingType=Long_implementations=6.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Int_implementations=0.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Int_implementations=2.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Int_implementations=4.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Int_implementations=6.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Long_implementations=0.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Long_implementations=2.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Long_implementations=4.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=20_backingType=Long_implementations=6.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Int_implementations=0.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Int_implementations=2.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Int_implementations=4.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Int_implementations=6.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Long_implementations=0.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Long_implementations=2.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Long_implementations=4.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=22_backingType=Long_implementations=6.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Int_implementations=0.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Int_implementations=2.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Int_implementations=4.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Int_implementations=6.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Long_implementations=0.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Long_implementations=2.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Long_implementations=4.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=24_backingType=Long_implementations=6.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Int_implementations=0.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Int_implementations=2.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Int_implementations=4.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Int_implementations=6.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Long_implementations=0.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Long_implementations=2.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Long_implementations=4.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=26_backingType=Long_implementations=6.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Int_implementations=0.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Int_implementations=2.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Int_implementations=4.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Int_implementations=6.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Long_implementations=0.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Long_implementations=2.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Long_implementations=4.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=28_backingType=Long_implementations=6.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Int_implementations=0.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Int_implementations=2.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Int_implementations=4.verified.txt
@@ -49,6 +49,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Int_implementations=6.verified.txt
@@ -49,6 +49,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Long_implementations=0.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Long_implementations=2.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Long_implementations=4.verified.txt
@@ -49,6 +49,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=30_backingType=Long_implementations=6.verified.txt
@@ -49,6 +49,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Int_implementations=0.verified.txt
@@ -45,6 +45,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Int_implementations=2.verified.txt
@@ -45,6 +45,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Int_implementations=4.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Int_implementations=6.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Long_implementations=0.verified.txt
@@ -45,6 +45,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Long_implementations=2.verified.txt
@@ -45,6 +45,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Long_implementations=4.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=48_backingType=Long_implementations=6.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Int_implementations=0.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Int_implementations=2.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Int_implementations=4.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Int_implementations=6.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Long_implementations=0.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Long_implementations=2.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Long_implementations=4.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=50_backingType=Long_implementations=6.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Int_implementations=0.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Int_implementations=2.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Int_implementations=4.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Int_implementations=6.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Long_implementations=0.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Long_implementations=2.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Long_implementations=4.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=52_backingType=Long_implementations=6.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Int_implementations=0.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Int_implementations=2.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Int_implementations=4.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Int_implementations=6.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Long_implementations=0.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Long_implementations=2.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Long_implementations=4.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=54_backingType=Long_implementations=6.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Int_implementations=0.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Int_implementations=2.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Int_implementations=4.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Int_implementations=6.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Long_implementations=0.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Long_implementations=2.verified.txt
@@ -46,6 +46,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Long_implementations=4.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=56_backingType=Long_implementations=6.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Int_implementations=0.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Int_implementations=2.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Int_implementations=4.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Int_implementations=6.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Long_implementations=0.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Long_implementations=2.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Long_implementations=4.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=58_backingType=Long_implementations=6.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Int_implementations=0.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Int_implementations=2.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Int_implementations=4.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Int_implementations=6.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Long_implementations=0.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Long_implementations=2.verified.txt
@@ -47,6 +47,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Long_implementations=4.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=60_backingType=Long_implementations=6.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Int_implementations=0.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Int_implementations=2.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Int_implementations=4.verified.txt
@@ -49,6 +49,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Int_implementations=6.verified.txt
@@ -49,6 +49,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Long_implementations=0.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Long_implementations=2.verified.txt
@@ -48,6 +48,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Long_implementations=4.verified.txt
@@ -49,6 +49,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=Some.Namespace_converter=62_backingType=Long_implementations=6.verified.txt
@@ -49,6 +49,18 @@ namespace Some.Namespace
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Int.verified.txt
@@ -41,4 +41,16 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Int_implementations=0.verified.txt
@@ -43,4 +43,16 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Int_implementations=2.verified.txt
@@ -43,4 +43,16 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Int_implementations=4.verified.txt
@@ -44,4 +44,16 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Int_implementations=6.verified.txt
@@ -44,4 +44,16 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Long.verified.txt
@@ -41,4 +41,16 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Long_implementations=0.verified.txt
@@ -43,4 +43,16 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Long_implementations=2.verified.txt
@@ -43,4 +43,16 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Long_implementations=4.verified.txt
@@ -44,4 +44,16 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=16_backingType=Long_implementations=6.verified.txt
@@ -44,4 +44,16 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
     }

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Int.verified.txt
@@ -42,6 +42,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Int_implementations=0.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Int_implementations=2.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Int_implementations=4.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Int_implementations=6.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Long.verified.txt
@@ -42,6 +42,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Long_implementations=0.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Long_implementations=2.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Long_implementations=4.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=18_backingType=Long_implementations=6.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Int.verified.txt
@@ -42,6 +42,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Int_implementations=0.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Int_implementations=2.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Int_implementations=4.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Int_implementations=6.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Long.verified.txt
@@ -42,6 +42,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Long_implementations=0.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Long_implementations=2.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Long_implementations=4.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=20_backingType=Long_implementations=6.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Int.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Int_implementations=0.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Int_implementations=2.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Int_implementations=4.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Int_implementations=6.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Long.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Long_implementations=0.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Long_implementations=2.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Long_implementations=4.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=22_backingType=Long_implementations=6.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Int.verified.txt
@@ -42,6 +42,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Int_implementations=0.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Int_implementations=2.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Int_implementations=4.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Int_implementations=6.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Long.verified.txt
@@ -42,6 +42,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Long_implementations=0.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Long_implementations=2.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Long_implementations=4.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=24_backingType=Long_implementations=6.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdSystemTextJsonConverter : System.Text.Json.Serialization.JsonConverter<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Int.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Int_implementations=0.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Int_implementations=2.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Int_implementations=4.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Int_implementations=6.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Long.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Long_implementations=0.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Long_implementations=2.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Long_implementations=4.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=26_backingType=Long_implementations=6.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Int.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Int_implementations=0.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Int_implementations=2.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Int_implementations=4.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Int_implementations=6.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Long.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Long_implementations=0.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Long_implementations=2.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Long_implementations=4.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=28_backingType=Long_implementations=6.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdNewtonsoftJsonConverter : Newtonsoft.Json.JsonConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Int.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Int_implementations=0.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Int_implementations=2.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Int_implementations=4.verified.txt
@@ -47,6 +47,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Int_implementations=6.verified.txt
@@ -47,6 +47,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Long.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Long_implementations=0.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Long_implementations=2.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Long_implementations=4.verified.txt
@@ -47,6 +47,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=30_backingType=Long_implementations=6.verified.txt
@@ -47,6 +47,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         class MyTestIdTypeConverter : System.ComponentModel.TypeConverter
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Int_implementations=0.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Int_implementations=2.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Int_implementations=4.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Int_implementations=6.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Long.verified.txt
@@ -41,6 +41,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Long_implementations=0.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Long_implementations=2.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Long_implementations=4.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=48_backingType=Long_implementations=6.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Int.verified.txt
@@ -42,6 +42,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Int_implementations=0.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Int_implementations=2.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Int_implementations=4.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Int_implementations=6.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Long.verified.txt
@@ -42,6 +42,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Long_implementations=0.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Long_implementations=2.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Long_implementations=4.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=50_backingType=Long_implementations=6.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Int.verified.txt
@@ -42,6 +42,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Int_implementations=0.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Int_implementations=2.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Int_implementations=4.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Int_implementations=6.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Long.verified.txt
@@ -42,6 +42,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Long_implementations=0.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Long_implementations=2.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Long_implementations=4.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=52_backingType=Long_implementations=6.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Int.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Int_implementations=0.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Int_implementations=2.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Int_implementations=4.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Int_implementations=6.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Long.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Long_implementations=0.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Long_implementations=2.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Long_implementations=4.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=54_backingType=Long_implementations=6.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Int.verified.txt
@@ -42,6 +42,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Int_implementations=0.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Int_implementations=2.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Int_implementations=4.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Int_implementations=6.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Long.verified.txt
@@ -42,6 +42,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Long_implementations=0.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Long_implementations=2.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Long_implementations=4.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=56_backingType=Long_implementations=6.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Int.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Int_implementations=0.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Int_implementations=2.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Int_implementations=4.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Int_implementations=6.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Long.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Long_implementations=0.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Long_implementations=2.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Long_implementations=4.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=58_backingType=Long_implementations=6.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Int.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Int_implementations=0.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Int_implementations=2.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Int_implementations=4.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Int_implementations=6.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Long.verified.txt
@@ -43,6 +43,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Long_implementations=0.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Long_implementations=2.verified.txt
@@ -45,6 +45,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Long_implementations=4.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=60_backingType=Long_implementations=6.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Int.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Int.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Int_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Int_implementations=0.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Int_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Int_implementations=2.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Int_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Int_implementations=4.verified.txt
@@ -47,6 +47,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Int_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Int_implementations=6.verified.txt
@@ -47,6 +47,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private int _id = int.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Long.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Long.verified.txt
@@ -44,6 +44,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Long_implementations=0.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Long_implementations=0.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Long_implementations=2.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Long_implementations=2.verified.txt
@@ -46,6 +46,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Long_implementations=4.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Long_implementations=4.verified.txt
@@ -47,6 +47,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {

--- a/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Long_implementations=6.verified.txt
+++ b/test/StronglyTypedIds.Tests/Snapshots/SourceGenerationHelperSnapshotTests.GeneratesIdCorrectly_ns=_converter=62_backingType=Long_implementations=6.verified.txt
@@ -47,6 +47,18 @@
                     mappingHints
                 ) { }
         }
+        
+        public class EfCoreValueGenerator : Microsoft.EntityFrameworkCore.ValueGeneration.ValueGenerator<MyTestId>
+        {
+            private long _id = long.MinValue;
+            public override bool GeneratesTemporaryValues => true;
+
+            public override MyTestId Next(Microsoft.EntityFrameworkCore.ChangeTracking.EntityEntry entry)
+            {
+                _id += 1;
+                return new MyTestId(_id);
+            }
+        }
 
         public class DapperTypeHandler : Dapper.SqlMapper.TypeHandler<MyTestId>
         {


### PR DESCRIPTION
This could be useful for identity columns in SQL databases. 
Not sure if this should potentially be treated as its own generator, currently just extended the templates for the EF Int and Long converters.

Sample usage when configuring EF Tables
```csharp
 modelBuilder
        .Entity<Entity>(builder =>
        {
            builder
                .Property(x => x.Id)
                .HasConversion(new EntityId.EfCoreValueConverter())
                .HasValueGenerator<EntityId.EfCoreValueGenerator>()
                .ValueGeneratedOnAdd();
        });
```