### PR TITLE
Fix EquatableArray.Equals override to avoid an endless recursion with a stackoverflow exception

### DIFF
--- a/src/StronglyTypedIds/EquatableArray.cs
+++ b/src/StronglyTypedIds/EquatableArray.cs
@@ -37,7 +37,7 @@ internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnu
     /// <sinheritdoc/>
     public override bool Equals(object? obj)
     {
-        return obj is EquatableArray<T> array && Equals(this, array);
+        return obj is EquatableArray<T> array && Equals(array);
     }
 
     /// <sinheritdoc/>

--- a/test/StronglyTypedIds.Tests/EqualityTests.cs
+++ b/test/StronglyTypedIds.Tests/EqualityTests.cs
@@ -149,4 +149,12 @@ public class EqualityTests
             return new Result<(StructToGenerate, bool)>((instance, true), errors);
         }
     }
+
+    [Fact]
+    public void EquatableArrayOverridenEqualsComparesAsExpected() {
+        var instance = new EquatableArray<string>(["A"]);
+        object comparand = new EquatableArray<string>(["A"]);
+
+        Assert.True(instance.Equals(comparand));
+    }
 }


### PR DESCRIPTION
Fixes an error in `EquatableArray.Equals(object?)` which currently ends in an `StackOverflowException` due to an endless recursion.