### PR TITLE
Use ArgumentNullException.ThrowIfNull when supported

### DIFF
--- a/src/StronglyTypedIds.Templates/string-full.typedid
+++ b/src/StronglyTypedIds.Templates/string-full.typedid
@@ -14,7 +14,12 @@
 
         public PLACEHOLDERID(string value)
         {
+#if NET7_0_OR_GREATER
+            global::System.ArgumentNullException.ThrowIfNull(value);
+            Value = value;
+#else
             Value = value ?? throw new global::System.ArgumentNullException(nameof(value));
+#endif
         }
 
         public static readonly PLACEHOLDERID Empty = new PLACEHOLDERID(string.Empty);

--- a/src/StronglyTypedIds/EmbeddedSources.String.cs
+++ b/src/StronglyTypedIds/EmbeddedSources.String.cs
@@ -16,7 +16,12 @@ internal static partial class EmbeddedSources
     
             public PLACEHOLDERID(string value)
             {
+    #if NET7_0_OR_GREATER
+                global::System.ArgumentNullException.ThrowIfNull(value);
+                Value = value;
+    #else
                 Value = value ?? throw new global::System.ArgumentNullException(nameof(value));
+    #endif
             }
     
             public static readonly PLACEHOLDERID Empty = new PLACEHOLDERID(string.Empty);


### PR DESCRIPTION
Because string-based typed id construction is usually in hot path, it makes sense to remove exception throwing from constructor. Any exception throwing disables the ability to inline the code in question. Using NET 7's new `ArgumentNullException.ThrowIfNull` for the simples implementation.