### PR TITLE
Hide templates by default (but make it configurable)

### DIFF
--- a/.github/workflows/BuildAndPack.yml
+++ b/.github/workflows/BuildAndPack.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   ubuntu-latest:
     name: ubuntu-latest
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04 # 24.04 can't run < net6.0
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4

--- a/src/StronglyTypedIds.Templates/StronglyTypedId.Templates.props
+++ b/src/StronglyTypedIds.Templates/StronglyTypedId.Templates.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <ShowStronglyTypedIdTemplates>false</ShowStronglyTypedIdTemplates>
+  </PropertyGroup>
+</Project>

--- a/src/StronglyTypedIds.Templates/StronglyTypedId.Templates.targets
+++ b/src/StronglyTypedIds.Templates/StronglyTypedId.Templates.targets
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <AdditionalFiles Include="$(MSBuildThisFileDirectory)AdditionalFiles\**">
-      <Visible>true</Visible>
+      <Visible>$(ShowStronglyTypedIdTemplates)</Visible>
     </AdditionalFiles>
   </ItemGroup>
 </Project>

--- a/src/StronglyTypedIds.Templates/StronglyTypedIds.Templates.csproj
+++ b/src/StronglyTypedIds.Templates/StronglyTypedIds.Templates.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <None Include="StronglyTypedId.Templates.targets" Pack="true" PackagePath="build" Visible="false" />
+    <None Include="StronglyTypedId.Templates.props" Pack="true" PackagePath="build" Visible="false" />
     <None Include=".\*.typedid" Pack="true" PackagePath="build/AdditionalFiles" Visible="false" />
   </ItemGroup>
 


### PR DESCRIPTION
They're hidden by default now - to make them visible, you can set

```xml
<ShowStronglyTypedIdTemplates>true</ShowStronglyTypedIdTemplates>
```

Fixes #139